### PR TITLE
refactor: keyword param handling

### DIFF
--- a/test/plug/redirect_test.exs
+++ b/test/plug/redirect_test.exs
@@ -16,8 +16,8 @@ defmodule Plug.RedirectTest do
     redirect("/users/:slug", "/profile/:slug")
     redirect("/other/:slug", "http://somewhere.com/profile/:slug")
 
-    redirect("/pages?type=modern", "/pages/modern", status: 301, query: true)
-    redirect("/pages?type=old", "/pages?type=new", status: 302, query: true)
+    redirect("/pages?type=modern", "/pages/modern", query: true)
+    redirect("/pages?type=old", "/pages?type=new", query: true, status: 302)
 
     # Old API
     redirect(301, "/old/foo/bar", "/go/here")


### PR DESCRIPTION
Tackles the problem of keyword sequence and demands, ie status became compulsory if you wanted to do a query redirect. The sequence also matters with status having to come before the query.

This pr then moves to an options block and conditional within versus pattern matching. Pattern matching keywords was suggest to be avoided within macro programming, or generally.